### PR TITLE
Redirect root index to campaign landing page

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,20 @@
+name: Deploy Pages
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+jobs:
+  deploy:
+    permissions:
+      pages: write
+      id-token: write
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Upload static site
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,37 +1,49 @@
-# ARP-RDM3DC
+# ARP-RDM3DC Site
 
-## Website Status: ✅ LIVE
+Static landing page for Adaptive π — the 4D, curve-native CAD campaign.
 
-**Public URL:** https://rdm3dc.github.io/ARP-RDM3DC/
+## Live deployment
 
-## About
+- **Production URL:** https://rdm3dc.github.io/ARP-RDM3DC/
+- **Hosting:** GitHub Pages (deployed by GitHub Actions)
 
-This repository hosts a live website deployed via GitHub Pages. The website provides information about the ARP-RDM3DC project status and accessibility.
+Every push to the `main` branch publishes the contents of [`site/`](site/) via the workflow in [`.github/workflows/pages.yml`](.github/workflows/pages.yml).
 
-## Deployment
+## Project structure
 
-The website is automatically deployed to GitHub Pages whenever changes are pushed to the main branch. The deployment is handled by GitHub's built-in Pages service.
+```
+ARP-RDM3DC/
+├── index.html             # Redirect shim → site/index.html for local previews
+├── site/
+│   ├── index.html         # Landing page served by GitHub Pages
+│   └── assets/            # Videos, posters, logos, screenshots
+└── .github/workflows/
+    └── pages.yml          # Static deploy pipeline
+```
 
-### Local Development
+### Updating the hero video
 
-To test the website locally:
+1. Replace `site/assets/hero.mp4` with the latest teaser (keep filename).
+2. (Optional) Host a poster image and update the `<video poster="…">` attribute in [`site/index.html`](site/index.html) if you do not want to use the default inline gradient placeholder.
+3. Remove the filenames from [`site/assets/.gitignore`](site/assets/.gitignore) if you want to commit the media, then commit the changes so the deploy workflow uploads them to Pages.
 
-1. Clone the repository
-2. Open `index.html` in a web browser
-3. Or serve it using a simple HTTP server:
-   ```bash
-   python3 -m http.server 8000
-   # Then visit http://localhost:8000
-   ```
+### Customising copy & CTA
 
-## Files
+- Update Kickstarter links inside [`site/index.html`](site/index.html) once the final campaign URL is ready.
+- Feature cards, rewards, and roadmap blurbs are pure HTML — adjust text or add new cards as needed.
 
-- `index.html` - Main website page
-- `start.py` - Original project file
-- `README.md` - This documentation
+### Local development
 
-## Project Information
+The site is fully static. Open `site/index.html` directly in a browser or run a lightweight HTTP server:
 
-- **Repository:** RDM3DC/ARP-RDM3DC
-- **Deployment:** GitHub Pages
-- **Status:** Live and publicly accessible
+```bash
+cd site
+python3 -m http.server 8000
+# Visit http://localhost:8000
+```
+
+> Tip: opening the repository root `index.html` will instantly redirect to `site/index.html`, so local previews show the live layout without needing to remember the subfolder.
+
+### Contact
+
+Reach out via [ryanmckenna26@gmail.com](mailto:ryanmckenna26@gmail.com) or text **951‑392‑0096** for any content updates.

--- a/index.html
+++ b/index.html
@@ -1,164 +1,77 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>RDM3DC — Adaptive Systems</title>
-    <meta name="description" content="RDM3DC — Adaptive research, prototyping, and apps.">
-    <link rel="icon" href="assets/channels4_profile.jpg">
-    <!-- Tailwind CDN for a zero-build static site -->
-    <script src="https://cdn.tailwindcss.com"></script>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Adaptive π — Launch</title>
+    <meta name="description" content="Adaptive π 4D CAD campaign landing page." />
+    <meta http-equiv="refresh" content="0; url=site/index.html" />
+    <script>
+      window.location.replace('site/index.html');
+    </script>
     <style>
-      /* Tiny helpers (kept minimal to stay self-contained) */
-      .container-7xl{ max-width: 80rem; margin-left:auto; margin-right:auto; padding-left:1rem; padding-right:1rem }
-      @media (min-width:640px){ .container-7xl{ padding-left:1.5rem; padding-right:1.5rem } }
-      @media (min-width:1024px){ .container-7xl{ padding-left:2rem; padding-right:2rem } }
-      .card{ border-radius:1rem; border:1px solid rgb(255 255 255 / 0.1); background: rgb(255 255 255 / 0.05) }
-      .btn{ display:inline-flex; align-items:center; justify-content:center; border-radius:1rem; padding:.5rem 1rem; font-weight:500 }
-      .btn-primary{ background: rgba(34,211,238,0.9); color:#0f172a }
-      .btn-primary:hover{ background: rgba(34,211,238,1) }
-      .btn-secondary{ background: rgba(255,255,255,0.1); color:white }
-      .btn-secondary:hover{ background: rgba(255,255,255,0.2) }
-      .input{ width:100%; border-radius:.75rem; background:rgba(255,255,255,0.05); border:1px solid rgba(255,255,255,0.1); padding:.75rem 1rem; outline:none }
-      .input:focus{ box-shadow: 0 0 0 2px rgba(34,211,238,0.6) }
+      :root {
+        color-scheme: dark;
+      }
+      body {
+        font-family: "Inter", system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        background: radial-gradient(circle at 20% 20%, rgba(127,244,244,0.12), transparent 55%),
+          radial-gradient(circle at 80% 30%, rgba(244,138,225,0.12), transparent 60%),
+          #080d16;
+        color: #e2e8f0;
+        text-align: center;
+        padding: 2rem;
+      }
+      main {
+        max-width: 28rem;
+        display: grid;
+        gap: 1rem;
+        padding: 2.5rem;
+        border-radius: 1.5rem;
+        border: 1px solid rgba(255,255,255,0.08);
+        background: rgba(10,14,24,0.7);
+        backdrop-filter: blur(12px);
+      }
+      a {
+        color: #7ff4f4;
+        font-weight: 600;
+        text-decoration: none;
+      }
+      a:hover {
+        text-decoration: underline;
+      }
+      .cta {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 0.75rem 1.5rem;
+        border-radius: 999px;
+        background: #2dd4bf;
+        color: #0f172a;
+        font-weight: 600;
+      }
+      .cta:hover {
+        background: #5eead4;
+      }
+      .contact {
+        font-size: 0.875rem;
+        color: #94a3b8;
+      }
     </style>
   </head>
-  <body class="bg-slate-950 text-slate-100">
-    <!-- Header -->
-    <header class="sticky top-0 z-50 backdrop-blur bg-slate-950/60 border-b border-white/5">
-      <div class="container-7xl h-16 flex items-center justify-between">
-        <div class="flex items-center gap-2">
-          <img src="assets/channels4_profile.jpg" alt="RDM3DC logo" class="h-8 w-8 rounded-xl">
-          <span class="font-semibold tracking-tight">RDM3DC</span>
-        </div>
-        <nav class="hidden md:flex items-center gap-6 text-sm text-slate-300">
-          <a href="#divisions" class="hover:text-white">Divisions</a>
-          <a href="#projects" class="hover:text-white">Projects</a>
-          <a href="#why" class="hover:text-white">Why Us</a>
-          <a href="#contact" class="hover:text-white">Contact</a>
-        </nav>
-        <a href="#contact" class="btn btn-primary text-sm">RDM3DC</a>
-      </div>
-    </header>
-
-    <!-- Hero -->
-    <section class="relative overflow-hidden">
-      <div class="absolute inset-0 -z-10 opacity-30" style="mask-image:radial-gradient(60% 50% at 50% 40%,black,transparent)">
-        <div class="absolute -top-24 left-1/2 -translate-x-1/2 h-[36rem] w-[36rem] rounded-full bg-gradient-to-tr from-cyan-600/60 via-blue-500/60 to-teal-500/60 blur-3xl"></div>
-      </div>
-      <div class="container-7xl py-20 md:py-28 text-center">
-        <h1 class="text-4xl md:text-6xl font-semibold tracking-tight">Building <span class="text-cyan-300">Adaptive</span> Systems that Learn, Align & Ship</h1>
-        <p class="mt-5 text-slate-300 max-w-2xl mx-auto">
-          From ARP and RealignR to ER‑fluid prototypes and production‑ready tools — RDM3DC unifies research, engineering, and product.
-        </p>
-        <div class="mt-8 flex flex-col sm:flex-row gap-3 justify-center">
-          <a href="#projects" class="btn btn-primary text-base">Explore projects <span class="ml-2">→</span></a>
-          <a href="#contact" class="btn btn-secondary text-base">Partner</a>
-        </div>
-      </div>
-    </section>
-
-    <!-- Divisions -->
-    <section id="divisions" class="container-7xl py-16">
-      <h2 class="text-2xl md:text-3xl font-semibold tracking-tight">Divisions</h2>
-      <p class="text-slate-300 mt-2 max-w-2xl">Organized to stay fast: research in Labs, product in Prototyping, verifiable science on‑chain, and customer apps in Apps.</p>
-      <div class="mt-8 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-        <div class="card p-5"><div class="text-lg font-medium">RDM3DC Labs</div><div class="text-sm text-slate-300 mt-1">ARP, RealignR, adaptive geometry — core research, papers, and open repos.</div></div>
-        <div class="card p-5"><div class="text-lg font-medium">Prototyping</div><div class="text-sm text-slate-300 mt-1">CAD, 3D printing, ER‑fluid devices, robotics, and rapid product development.</div></div>
-        <div class="card p-5"><div class="text-lg font-medium">Blockchain & Verification</div><div class="text-sm text-slate-300 mt-1">Reproducibility, verifiable experiments, audit trails, and open attestations.</div></div>
-        <div class="card p-5"><div class="text-lg font-medium">Apps</div><div class="text-sm text-slate-300 mt-1">Research dashboards, optimizer UIs, and realtime geo‑aware tools.</div></div>
-      </div>
-    </section>
-
-    <!-- Projects -->
-    <section id="projects" class="container-7xl py-16">
-      <div class="flex items-end justify-between gap-4">
-        <h2 class="text-2xl md:text-3xl font-semibold tracking-tight">Featured Projects</h2>
-        <a class="text-sm text-cyan-300 hover:text-white" href="https://github.com/RDM3DC" target="_blank" rel="noreferrer">All GitHub ↗</a>
-      </div>
-      <div class="mt-8 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-        <div class="card p-5 hover:bg-white/[0.07] transition-colors">
-          <div class="text-xs uppercase tracking-wide text-cyan-300/80">Research</div>
-          <div class="mt-1 text-lg font-medium">Adaptive Resistance Principle (ARP)</div>
-          <p class="text-sm text-slate-300 mt-2">A dynamic systems law used for optimization, analog computing, and ML stability.</p>
-          <div class="mt-4"><a class="btn btn-secondary text-sm" target="_blank" rel="noreferrer" href="https://github.com/RDM3DC/Adaptive-Resistance-Principle-ARP-">View repo</a></div>
-        </div>
-        <div class="card p-5 hover:bg-white/[0.07] transition-colors">
-          <div class="text-xs uppercase tracking-wide text-cyan-300/80">Optimizer</div>
-          <div class="mt-1 text-lg font-medium">RealignR</div>
-          <p class="text-sm text-slate-300 mt-2">A lifelong optimizer with slope‑aware memory and ARP integration.</p>
-          <div class="mt-4"><a class="btn btn-secondary text-sm" target="_blank" rel="noreferrer" href="https://github.com/RDM3DC/realignerpreview">See docs</a></div>
-        </div>
-        <div class="card p-5 hover:bg-white/[0.07] transition-colors">
-          <div class="text-xs uppercase tracking-wide text-cyan-300/80">CAD</div>
-          <div class="mt-1 text-lg font-medium">AdaptiveCAD</div>
-          <p class="text-sm text-slate-300 mt-2">Geometry that bends with constraints — πₐ, curve memory, and plugins.</p>
-          <div class="mt-4"><a class="btn btn-secondary text-sm" target="_blank" rel="noreferrer" href="https://github.com/RDM3DC/AdaptiveCAD">Explore</a></div>
-        </div>
-        <div class="card p-5 hover:bg-white/[0.07] transition-colors">
-          <div class="text-xs uppercase tracking-wide text-cyan-300/80">Geometry</div>
-          <div class="mt-1 text-lg font-medium">Adaptive Pi Geometry (πₐ)</div>
-          <p class="text-sm text-slate-300 mt-2">Constraint‑bent π for curved designs, survey alignment, and physics demos.</p>
-          <div class="mt-4"><a class="btn btn-secondary text-sm" href="#" rel="noreferrer">Overview</a></div>
-        </div>
-        <div class="card p-5 hover:bg-white/[0.07] transition-colors">
-          <div class="text-xs uppercase tracking-wide text-cyan-300/80">Circuits</div>
-          <div class="mt-1 text-lg font-medium">Adaptive Impedance Network (AIN)</div>
-          <p class="text-sm text-slate-300 mt-2">Dynamic G/C/L networks for optimization, control, and robust signal paths.</p>
-          <div class="mt-4"><a class="btn btn-secondary text-sm" href="#" rel="noreferrer">Design notes</a></div>
-        </div>
-        <div class="card p-5 hover:bg-white/[0.07] transition-colors">
-          <div class="text-xs uppercase tracking-wide text-cyan-300/80">Hardware</div>
-          <div class="mt-1 text-lg font-medium">ER‑Fluid Analog Computer</div>
-          <p class="text-sm text-slate-300 mt-2">Electrorheological hardware for TSP‑style routing and field solvers.</p>
-          <div class="mt-4"><a class="btn btn-secondary text-sm" href="#" rel="noreferrer">Lab prototype</a></div>
-        </div>
-      </div>
-    </section>
-
-    <!-- Why Us -->
-    <section id="why" class="container-7xl py-16">
-      <div class="grid grid-cols-1 lg:grid-cols-3 gap-4">
-        <div class="card p-5"><div class="font-medium">Research → Product</div><div class="text-sm text-slate-300 mt-1">We bridge frontier math/physics with shipped tools. If it can be simulated, we can prototype it.</div></div>
-        <div class="card p-5"><div class="font-medium">Open‑core, IP‑aware</div><div class="text-sm text-slate-300 mt-1">Public repos where it helps adoption; protected IP where it matters for a moat.</div></div>
-        <div class="card p-5"><div class="font-medium">Fast Experiments</div><div class="text-sm text-slate-300 mt-1">Tight iteration loops: sim → prototype → field test. We ship proof fast and scale what works.</div></div>
-      </div>
-    </section>
-
-    <!-- Contact -->
-    <section id="contact" class="container-7xl py-20">
-      <div class="card p-8 md:p-10">
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
-          <div>
-            <h3 class="text-2xl font-semibold tracking-tight">Let’s build something adaptive.</h3>
-            <p class="mt-2 text-slate-300">Consulting, partnerships, or R&D collabs. Tell us what you’re trying to unlock.</p>
-            <div class="mt-6 flex flex-wrap gap-3">
-              <a class="btn btn-primary" href="mailto:ryanmckenna26@gmail.com">ryanmckenna26@gmail.com</a>
-              <a class="btn btn-secondary" href="https://github.com/RDM3DC" target="_blank" rel="noreferrer">GitHub</a>
-              <a class="btn btn-secondary" href="sms:9513920096">Text 951‑392‑0096</a>
-              <a class="btn text-slate-300 hover:text-white" href="https://x.com/RDM3DC" target="_blank" rel="noreferrer">Follow on X</a>
-            </div>
-          </div>
-          <form class="space-y-3" onsubmit="event.preventDefault(); alert('Thanks! This demo form does not send yet.');">
-            <input class="input" placeholder="Your name">
-            <input class="input" placeholder="Email">
-            <textarea rows="5" class="input" placeholder="What would you like to build?"></textarea>
-            <button class="btn btn-primary w-full">Send message</button>
-          </form>
-        </div>
-      </div>
-    </section>
-
-    <!-- Footer -->
-    <footer class="border-t border-white/10">
-      <div class="container-7xl py-10 text-sm text-slate-400 flex flex-col md:flex-row items-center justify-between gap-3">
-        <div>© <span id="yr"></span> RDM3DC. All rights reserved.</div>
-        <div class="flex items-center gap-4">
-          <a class="hover:text-white" href="https://github.com/RDM3DC" target="_blank" rel="noreferrer">GitHub</a>
-          <a class="hover:text-white" href="mailto:ryanmckenna26@gmail.com">Email</a>
-        </div>
-      </div>
-      <script>document.getElementById('yr').textContent = new Date().getFullYear()</script>
-    </footer>
+  <body>
+    <main>
+      <h1>Redirecting to the Adaptive π campaign site…</h1>
+      <p>One moment — the new Kickstarter landing page lives at <code>site/index.html</code>.</p>
+      <p><a class="cta" href="site/index.html">Continue to Adaptive π</a></p>
+      <p class="contact">
+        Need to reach us directly? Email <a href="mailto:ryanmckenna26@gmail.com">ryanmckenna26@gmail.com</a>
+        or text <a href="sms:9513920096">951‑392‑0096</a>.
+      </p>
+    </main>
   </body>
 </html>

--- a/site/assets/.gitignore
+++ b/site/assets/.gitignore
@@ -1,0 +1,3 @@
+# Ignore heavy media placeholders by default.
+hero.mp4
+hero_poster.jpg

--- a/site/assets/README.md
+++ b/site/assets/README.md
@@ -1,0 +1,12 @@
+# Adaptive π assets
+
+Drop campaign media in this folder:
+
+- `hero.mp4` – hero teaser video used above the fold. (Ignored by git so you can keep big files local.)
+- `hero_poster.jpg` – optional poster frame if you prefer not to use the built-in gradient placeholder.
+- `logos/` – marks and lockups.
+- `screenshots/` – renders, product shots, or gameplay teasers.
+
+- `.gitignore` keeps large binaries (`hero.mp4`, `hero_poster.jpg`) out of version control by default. Remove entries if you intentionally want to commit the media.
+
+> Tip: keep filenames lowercase with dashes/underscores so links stay clean.

--- a/site/assets/logos/adaptivepi_mark.svg
+++ b/site/assets/logos/adaptivepi_mark.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="8" ry="8" fill="#8b5cf6"/>
+  <text x="50%" y="50%" font-size="20" text-anchor="middle" fill="#0f172a" dy=".35em">RDM</text>
+</svg>

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,258 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Adaptive π — 4D Curve-Native CAD</title>
+  <meta name="description" content="Adaptive π 4D CAD: curve-native, no tessellation, infinite scaling.">
+  <meta property="og:title" content="Adaptive π — 4D Curve-Native CAD" />
+  <meta property="og:description" content="Curve-native, multi-dimensional CAD with analytic rendering and infinite scaling." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://rdm3dc.github.io/ARP-RDM3DC/" />
+  <meta property="og:image" content="https://rdm3dc.github.io/ARP-RDM3DC/assets/logos/adaptivepi_mark.svg" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Adaptive π — 4D Curve-Native CAD" />
+  <meta name="twitter:description" content="Back Adaptive π to bring 4D, curve-native CAD with no tessellation and infinite scaling to life." />
+  <meta name="twitter:image" content="https://rdm3dc.github.io/ARP-RDM3DC/assets/logos/adaptivepi_mark.svg" />
+  <link rel="icon" href="assets/logos/adaptivepi_mark.svg" type="image/svg+xml">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;800&display=swap" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    :root {
+      --bg0:#070911; --bg1:#101b2d; --glass:rgba(255,255,255,0.06);
+      --cy:#7ff4f4; --mag:#f48ae1; --yel:#ffd98a; --mut:#9fb6d1;
+    }
+    body { font-family: "Inter", system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; }
+    .card { background: var(--glass); border: 1px solid rgba(255,255,255,0.08); }
+    .pill { background: rgba(127,244,244,0.12); border: 1px solid rgba(127,244,244,0.35); }
+    .grad { background:
+      radial-gradient(1200px 700px at 60% -10%, #14324a 0%, transparent 60%),
+      radial-gradient(900px 600px at -10% 20%, #2d1141 0%, transparent 55%),
+      linear-gradient(180deg, var(--bg0), var(--bg1));
+    }
+    .card-grid { background-image: linear-gradient(135deg, rgba(127,244,244,0.08) 0%, rgba(127,244,244,0) 60%); }
+  </style>
+</head>
+<body class="grad text-slate-200">
+  <header class="max-w-6xl mx-auto px-6 py-6 flex items-center justify-between">
+    <div class="flex items-center gap-3">
+      <img src="assets/logos/adaptivepi_mark.svg" class="w-9 h-9" alt="Adaptive π logo">
+      <span class="font-extrabold tracking-tight text-lg">Adaptive π</span>
+    </div>
+    <nav class="hidden md:flex items-center gap-6 text-sm text-slate-300">
+      <a href="#features" class="hover:text-white">Features</a>
+      <a href="#video" class="hover:text-white">Video</a>
+      <a href="#rewards" class="hover:text-white">Rewards</a>
+      <a href="#roadmap" class="hover:text-white">Roadmap</a>
+      <a href="#contact" class="hover:text-white">Contact</a>
+      <a href="https://github.com/RDM3DC/AdaptiveCAD" class="hover:text-white">GitHub</a>
+      <!-- Replace the Kickstarter URL once the campaign link is ready -->
+      <a href="https://www.kickstarter.com/" class="ml-3 px-4 py-2 rounded-xl bg-teal-400/20 border border-teal-300/50 hover:bg-teal-300/30 text-teal-200">Back on Kickstarter</a>
+    </nav>
+  </header>
+
+  <section class="max-w-6xl mx-auto px-6 pt-6 pb-10">
+    <div class="grid md:grid-cols-2 gap-10 items-center">
+      <div>
+        <div class="inline-flex gap-2 items-center pill px-3 py-1 rounded-full text-teal-200 text-xs mb-4">
+          <span>4D CAD</span><span class="text-slate-400">•</span><span>No tessellation</span><span class="text-slate-400">•</span><span>Infinite scaling</span>
+        </div>
+        <h1 class="text-4xl md:text-6xl font-extrabold leading-tight">
+          Adaptive π — The first 4D, curve-native CAD.
+        </h1>
+        <p class="text-slate-300 mt-4 text-lg">
+          No tessellation. Infinite scaling. Build with analytic geometry that keeps every curve smooth
+          from concept to field deployment.
+        </p>
+        <div class="mt-6 flex flex-wrap gap-3">
+          <a href="https://www.kickstarter.com/" class="px-5 py-3 rounded-xl bg-teal-500 text-slate-900 font-semibold hover:bg-teal-400">Back on Kickstarter</a>
+          <a href="#video" class="px-5 py-3 rounded-xl border border-slate-600 hover:border-slate-400">Watch the Demo</a>
+        </div>
+        <div class="mt-5 flex flex-wrap gap-2 text-xs text-slate-400">
+          <span class="px-2 py-1 rounded pill">Civil add-on (survey &amp; alignments)</span>
+          <span class="px-2 py-1 rounded pill">Future game engine</span>
+          <span class="px-2 py-1 rounded pill">AMA / ACProj format</span>
+        </div>
+      </div>
+      <div id="video" class="card rounded-2xl overflow-hidden">
+        <video
+          controls
+          playsinline
+          preload="metadata"
+          poster="data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20viewBox%3D%270%200%201200%20675%27%20preserveAspectRatio%3D%27none%27%3E%3Cdefs%3E%3ClinearGradient%20id%3D%27g%27%20x1%3D%270%25%27%20y1%3D%270%25%27%20x2%3D%27100%25%27%20y2%3D%27100%25%27%3E%3Cstop%20stop-color%3D%27%2309171f%27%20offset%3D%270%25%27/%3E%3Cstop%20stop-color%3D%27%231a3450%27%20offset%3D%2750%25%27/%3E%3Cstop%20stop-color%3D%27%232d1141%27%20offset%3D%27100%25%27/%3E%3C/linearGradient%3E%3C/defs%3E%3Crect%20fill%3D%27url%28%23g%29%27%20width%3D%271200%27%20height%3D%27675%27/%3E%3Cg%20fill%3D%27%237ff4f4%27%20font-family%3D%27Inter%2C%20Arial%2C%20sans-serif%27%20text-anchor%3D%27middle%27%3E%3Ctext%20x%3D%2750%25%27%20y%3D%2745%25%27%20font-size%3D%2758%27%3EDrop%20your%20hero.mp4%3C/text%3E%3Ctext%20x%3D%2750%25%27%20y%3D%2760%25%27%20font-size%3D%2736%27%20fill%3D%27%239fb6d1%27%3Esite/assets/hero.mp4%3C/text%3E%3C/g%3E%3C/svg%3E"
+          class="block w-full h-auto bg-slate-900/60"
+        >
+          <source src="assets/hero.mp4" type="video/mp4">
+          <p class="p-4 text-sm text-slate-300 bg-slate-900/70">Drop your hero.mp4 teaser into <code>site/assets/hero.mp4</code> to play the video.</p>
+        </video>
+        <div class="px-5 py-3 text-xs text-slate-400 bg-slate-900/60 border-t border-white/5">
+          Replace <code>site/assets/hero.mp4</code> with the Kickstarter teaser. To use a custom poster frame, host the image and update the <code>poster</code> attribute above.
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="features" class="max-w-6xl mx-auto px-6 pb-6">
+    <h2 class="text-2xl md:text-3xl font-bold mb-4">Why Adaptive π</h2>
+    <div class="grid md:grid-cols-3 gap-4">
+      <div class="card rounded-xl p-5">
+        <h3 class="font-semibold mb-2">No Tessellation</h3>
+        <p class="text-sm text-slate-300">Analytic curves and surfaces mean smooth geometry at any zoom level without triangle meshes.</p>
+      </div>
+      <div class="card rounded-xl p-5">
+        <h3 class="font-semibold mb-2">Infinite Scaling</h3>
+        <p class="text-sm text-slate-300">Resolution-independent rendering and export for fabrication, printing, or AR/VR twins.</p>
+      </div>
+      <div class="card rounded-xl p-5">
+        <h3 class="font-semibold mb-2">Multi-Dimensional</h3>
+        <p class="text-sm text-slate-300">Grade-aware algebra unlocks operations beyond 3D—time, fields, and constraints live together.</p>
+      </div>
+      <div class="card rounded-xl p-5">
+        <h3 class="font-semibold mb-2">Projected Wedge Algebra (⋆)</h3>
+        <p class="text-sm text-slate-300">Grade-2 closure with antisymmetric interactions and a compact Λ²V representation.</p>
+      </div>
+      <div class="card rounded-xl p-5">
+        <h3 class="font-semibold mb-2">Civil Add-On</h3>
+        <p class="text-sm text-slate-300">Alignment accuracy for construction survey modeling, corridor design, and field validation.</p>
+      </div>
+      <div class="card rounded-xl p-5">
+        <h3 class="font-semibold mb-2">Playground App</h3>
+        <p class="text-sm text-slate-300">Parametric editors, curve libraries, STL repair, and export tuned for creators.</p>
+      </div>
+    </div>
+  </section>
+
+  <section class="max-w-6xl mx-auto px-6 py-8">
+    <div class="card rounded-2xl card-grid p-8 flex flex-col lg:flex-row gap-8 lg:items-center">
+      <div class="lg:w-1/2">
+        <h2 class="text-2xl md:text-3xl font-bold mb-4">Pure math. Real hardware.</h2>
+        <p class="text-sm md:text-base text-slate-300">
+          Adaptive π fuses analytic geometry with tangible fabrication: analytic rendering on CPUs today,
+          GPUs tomorrow; ER-fluid control, CNC, and robotics aligned to the same math library.
+        </p>
+      </div>
+      <div class="lg:w-1/2 grid sm:grid-cols-2 gap-3 text-sm text-slate-300">
+        <div class="card rounded-xl p-4">
+          <div class="font-semibold text-slate-100">File Formats</div>
+          <p class="mt-1">AMA / ACProj with Blender and FreeCAD plugins on the roadmap.</p>
+        </div>
+        <div class="card rounded-xl p-4">
+          <div class="font-semibold text-slate-100">Survey Ready</div>
+          <p class="mt-1">Chainage-aware alignments with millimeter fidelity over kilometers.</p>
+        </div>
+        <div class="card rounded-xl p-4">
+          <div class="font-semibold text-slate-100">Game Engine Path</div>
+          <p class="mt-1">Projected to feed adaptive meshes for real-time, non-Euclidean scenes.</p>
+        </div>
+        <div class="card rounded-xl p-4">
+          <div class="font-semibold text-slate-100">Backer Community</div>
+          <p class="mt-1">Exclusive AMAs, roadmap votes, and early playground builds.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="rewards" class="max-w-6xl mx-auto px-6 py-8">
+    <h2 class="text-2xl md:text-3xl font-bold mb-4">Rewards</h2>
+    <div class="grid md:grid-cols-3 gap-4">
+      <div class="card rounded-xl p-5">
+        <h3 class="font-semibold mb-2">Early Backer</h3>
+        <ul class="text-sm list-disc list-inside text-slate-300 space-y-1">
+          <li>Playground access (alpha)</li>
+          <li>Backer badge</li>
+          <li>Private Discord access</li>
+        </ul>
+      </div>
+      <div class="card rounded-xl p-5">
+        <h3 class="font-semibold mb-2">Creator</h3>
+        <ul class="text-sm list-disc list-inside text-slate-300 space-y-1">
+          <li>Playground + civil preview</li>
+          <li>Export tools &amp; updates</li>
+          <li>Priority feedback loop</li>
+        </ul>
+      </div>
+      <div class="card rounded-xl p-5">
+        <h3 class="font-semibold mb-2">Pro</h3>
+        <ul class="text-sm list-disc list-inside text-slate-300 space-y-1">
+          <li>Priority features</li>
+          <li>Plugin dev support</li>
+          <li>Extended roadmap sessions</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <section id="roadmap" class="max-w-6xl mx-auto px-6 py-8">
+    <div class="grid lg:grid-cols-2 gap-6">
+      <div class="card rounded-2xl p-6">
+        <h2 class="text-2xl font-bold mb-2">Roadmap Highlights</h2>
+        <ul class="space-y-3 text-sm text-slate-300">
+          <li><span class="font-semibold text-slate-100">Alpha Playground:</span> Parametric editor, inspector, and analytic rendering with export.</li>
+          <li><span class="font-semibold text-slate-100">Civil Toolkit:</span> Corridor alignment, station equations, offset surfaces, and data QA.</li>
+          <li><span class="font-semibold text-slate-100">Open Plugins:</span> Blender / FreeCAD connectors, AMA SDK, and Python bindings.</li>
+          <li><span class="font-semibold text-slate-100">Field Ops:</span> GNSS + lidar ingestion, job replay, and AR overlays.</li>
+        </ul>
+      </div>
+      <div class="card rounded-2xl p-6">
+        <h2 class="text-2xl font-bold mb-2">Tech Stack</h2>
+        <ul class="space-y-3 text-sm text-slate-300">
+          <li><span class="font-semibold text-slate-100">Core Library:</span> Adaptive π projected wedge algebra with analytic kernels.</li>
+          <li><span class="font-semibold text-slate-100">Rendering:</span> CPU analytic renderer now; GPU acceleration and game engine integration next.</li>
+          <li><span class="font-semibold text-slate-100">Interoperability:</span> AMA, ACProj, IFC, LandXML, and STL repair pipelines.</li>
+          <li><span class="font-semibold text-slate-100">Collaboration:</span> Backer portal with nightly builds, tutorials, and surveys.</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <section id="contact" class="max-w-6xl mx-auto px-6 py-12">
+    <div class="card rounded-2xl p-8">
+      <div class="grid md:grid-cols-2 gap-8">
+        <div>
+          <h2 class="text-2xl md:text-3xl font-bold">Let’s build Adaptive π together</h2>
+          <p class="mt-3 text-sm md:text-base text-slate-300">
+            Partnerships, research collaborations, or press—reach out directly anytime.
+          </p>
+          <div class="mt-6 flex flex-wrap gap-3 text-sm">
+            <a class="px-4 py-2 rounded-xl bg-teal-500 text-slate-900 font-semibold hover:bg-teal-400" href="mailto:ryanmckenna26@gmail.com">ryanmckenna26@gmail.com</a>
+            <a class="px-4 py-2 rounded-xl border border-slate-600 hover:border-slate-400" href="sms:9513920096">Text 951-392-0096</a>
+            <a class="px-4 py-2 rounded-xl border border-slate-600 hover:border-slate-400" href="https://github.com/RDM3DC" target="_blank" rel="noreferrer">GitHub</a>
+            <a class="px-4 py-2 rounded-xl border border-slate-600 hover:border-slate-400" href="https://x.com/RDM3DC" target="_blank" rel="noreferrer">X (Twitter)</a>
+          </div>
+        </div>
+        <div class="space-y-4 text-sm text-slate-300">
+          <div>
+            <div class="font-semibold text-slate-100">Office Hours</div>
+            <p class="mt-1">Weekly AMAs for backers. Calendar invite provided after pledging.</p>
+          </div>
+          <div>
+            <div class="font-semibold text-slate-100">Updates</div>
+            <p class="mt-1">Kickstarter updates, newsletters, and technical write-ups on adaptive geometry.</p>
+          </div>
+          <div>
+            <div class="font-semibold text-slate-100">Media Kit</div>
+            <p class="mt-1">Logos and renders live in <code>site/assets/</code>. Swap in new art anytime.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <footer class="max-w-6xl mx-auto px-6 py-10 text-slate-400 text-sm">
+    <div class="flex flex-col md:flex-row items-center justify-between gap-3">
+      <div>© <span id="year"></span> RDM3DC — Adaptive π</div>
+      <div class="flex items-center gap-4">
+        <a href="https://github.com/RDM3DC/AdaptiveCAD" target="_blank" rel="noreferrer" class="hover:text-white">GitHub</a>
+        <a href="mailto:ryanmckenna26@gmail.com" class="hover:text-white">Email</a>
+        <a href="sms:9513920096" class="hover:text-white">951-392-0096</a>
+        <a href="https://www.kickstarter.com/" class="text-teal-300 hover:text-teal-200">Kickstarter</a>
+      </div>
+    </div>
+  </footer>
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- replace the repository root index with a redirect shim so opening the project locally forwards straight to the new campaign landing page while keeping contact details visible as a fallback.
- tighten the hero headline and Kickstarter CTA copy in `site/index.html` to highlight the "Adaptive π" 4D CAD launch message.
- document the redirect helper in the README so contributors know how to preview the site structure.

## Testing
- python -m compileall site

------
https://chatgpt.com/codex/tasks/task_e_68c9dcaac328832fbf282dc1cbd0873e