### PR TITLE
Add static blog and surface link in navigation

### DIFF
--- a/site/blog/adaptive-compression-suite.html
+++ b/site/blog/adaptive-compression-suite.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Adaptive Compression Suite</title>
+</head>
+<body>
+  <h1>Adaptive Compression Suite</h1>
+  <p>The Adaptive Compression Suite provides three complementary compression methods. ATC (adaptive text compression) strips visible spaces, punctuation and case and encodes them as style bytes alongside a compact carrier string. CMC (curve‑memory compression) encodes anchors at curvature or turning events and reconstructs signals with an ARP‑style smoother. GPUC (GPU/Tensor compression) applies quantization and zero‑suppression to numeric arrays, with an optional CUDA path via PyTorch. Command‑line tools and Python APIs demonstrate encoding and decoding for each method.</p>
+  <p><a href="index.html">Back to blog index</a></p>
+</body>
+</html>

--- a/site/blog/adaptive-curvature-blockchain.html
+++ b/site/blog/adaptive-curvature-blockchain.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Adaptive‑Curvature‑Blockchain (ACB)</title>
+</head>
+<body>
+  <h1>Adaptive‑Curvature‑Blockchain (ACB)</h1>
+  <p>Adaptive‑Curvature‑Blockchain replaces energy‑intensive proof‑of‑work with proof‑of‑optimization. Miners mint blocks by submitting improved solutions to a travelling‑salesman tour; the chain scores each block by how much the proposed tour improves over a baseline and selects the chain with the highest cumulative score. ACB features automatic difficulty retargeting based on recent successes, scoring rules derived from the baseline cost difference and simple API endpoints for status, chain retrieval and solution submission.</p>
+  <p><a href="index.html">Back to blog index</a></p>
+</body>
+</html>

--- a/site/blog/adaptive-demo-game.html
+++ b/site/blog/adaptive-demo-game.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Adaptive π Demo Game</title>
+</head>
+<body>
+  <h1>Adaptive π Demo Game</h1>
+  <p>The Adaptive π Demo Game is a curve‑native shooter prototype inspired by classic arcade shooters. Built on a lightweight kernel inspired by Adaptive π and AdaptiveCAD, it uses parametric geometry and non‑Euclidean rendering instead of triangle meshes. Players control their ship with the keyboard and shoot with the spacebar. The game includes a simple engine with curve primitives, entities and collision detection written in Python, and a roadmap suggests replacing primitive samplers with πₐ‑native curve objects and adding GPU‑backed rendering in future versions.</p>
+  <p><a href="index.html">Back to blog index</a></p>
+</body>
+</html>

--- a/site/blog/adaptive-dynamics-toolkit.html
+++ b/site/blog/adaptive-dynamics-toolkit.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Adaptive Dynamics Toolkit</title>
+</head>
+<body>
+  <h1>Adaptive Dynamics Toolkit</h1>
+  <p>The Adaptive Dynamics Toolkit is a unified framework that brings together adaptive π geometry, ARP optimization, physics simulations and compression algorithms. It installs easily via pip and includes examples showing how to compute curved geometry with the Adaptive π class, train neural networks with an ARP optimizer and visualize the results. Comprehensive documentation provides getting‑started guides, API references and tutorials, and a pro version extends the toolkit with CUDA acceleration and advanced features.</p>
+  <p><a href="index.html">Back to blog index</a></p>
+</body>
+</html>

--- a/site/blog/adaptive-golden-field.html
+++ b/site/blog/adaptive-golden-field.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Adaptive Golden Field</title>
+</head>
+<body>
+  <h1>Adaptive Golden Field</h1>
+  <p>Adaptive Golden Field makes the golden ratio dynamic. The recurrence \(F_n = F_{n−1} + r(x,t) F_{n−2}\) leads to a generalized ratio \(ϕ_a(x,t) = (1 + \sqrt{1 + 4 r(x,t)})/2\). Coupling the adaptive parameter r to a gravity‑like potential and tracing rays in an optical metric reveals caustics that surge, precess and ring. The repository includes scripts to simulate inspiral, precession and ringdown phases and to produce cinematic animations.</p>
+  <p><a href="index.html">Back to blog index</a></p>
+</body>
+</html>

--- a/site/blog/adaptive-gravity.html
+++ b/site/blog/adaptive-gravity.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Adaptive Gravity</title>
+</head>
+<body>
+  <h1>Adaptive Gravity — Galaxy Rotation Simulation</h1>
+  <p>Adaptive Gravity applies the Adaptive Resistance Principle to gravitational strength in galactic rotation curves. Gravity evolves according to \(\dot{G}(r,t) = \alpha \rho(r)^2 - \mu G(r,t)\) and enforces a pivot radius where all rotation curves cross. The model uses realistic Milky Way components such as a Hernquist bulge and an exponential disk and outputs rotation curves, acceleration profiles and CSV tables for further analysis.</p>
+  <p><a href="index.html">Back to blog index</a></p>
+</body>
+</html>

--- a/site/blog/adaptive-physics-engine.html
+++ b/site/blog/adaptive-physics-engine.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Adaptive Physics Engine</title>
+</head>
+<body>
+  <h1>Adaptive Physics Engine</h1>
+  <p>This real‑time physics engine models a charged‑particle beam steered by the Adaptive Resistance Principle (ARP) and adaptive π geometry. It includes a multi‑zone 3D simulator with modules for the injector, ARP electromagnetic chamber, resonance lens, adaptive π coil and target detector. A reinforcement feedback loop tunes the ARP parameters to minimize beam spread, and an interactive dashboard exposes sliders for field parameters and live visualization. The repository also contains schematics, CAD sketches and hardware notes for a bench‑top prototype.</p>
+  <p><a href="index.html">Back to blog index</a></p>
+</body>
+</html>

--- a/site/blog/adaptive-pi.html
+++ b/site/blog/adaptive-pi.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Adaptive π Geometry</title>
+</head>
+<body>
+  <h1>Adaptive π Geometry</h1>
+  <p>Adaptive π geometry is a lightweight Python library and reference specification that unifies Euclidean and curved geometry. It provides testable primitives that reduce to classical Euclidean results when curvature approaches zero and expose curvature corrections otherwise. The repository contains modules for angle sums, cyclicity, flux integrals and advanced constructions such as Ceva, Menelaus and Miquel points, along with examples and tests demonstrating the framework.</p>
+  <p><a href="index.html">Back to blog index</a></p>
+</body>
+</html>

--- a/site/blog/adaptive-platonic-catalogue.html
+++ b/site/blog/adaptive-platonic-catalogue.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Adaptive Platonic Catalogue</title>
+</head>
+<body>
+  <h1>Adaptive Platonic Catalogue</h1>
+  <p>This research repository extends the classical Platonic solid catalogue under adaptive π geometry. It encodes the existence rule with the ratio ρ = π<sub>v</sub>/π<sub>f</sub> and tests which regular {n,q} pairs satisfy 1/n + (ρ/q) > 1/2. When ρ = 1 the classical condition recovers exactly five Platonic solids; at other ratios new families appear. The project includes scripts to generate tables of admissible polyhedra, render patches, produce phase diagrams and create equation cards.</p>
+  <p><a href="index.html">Back to blog index</a></p>
+</body>
+</html>

--- a/site/blog/adaptive-quantum-coupling.html
+++ b/site/blog/adaptive-quantum-coupling.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Adaptive Quantum Coupling — Bell Chip</title>
+</head>
+<body>
+  <h1>Adaptive Quantum Coupling — Bell Chip</h1>
+  <p>This project studies quantum systems coupled to an Adaptive Resistance Principle (ARP) memory field in a “Bell chip” platform. It derives coupled equations in which the system’s state and a memory field evolve together. The framework enables tunable coherence, wavefunction steering, history‑dependent phase shifts and controllable decoherence. Closed‑form limits reveal how fast or slow memory regimes affect dynamics, and the repository includes scripts to reproduce key runs and plots.</p>
+  <p><a href="index.html">Back to blog index</a></p>
+</body>
+</html>

--- a/site/blog/adaptive-resistance-principle.html
+++ b/site/blog/adaptive-resistance-principle.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Adaptive Resistance Principle (ARP)</title>
+</head>
+<body>
+  <h1>Adaptive Resistance Principle (ARP)</h1>
+  <p>The Adaptive Resistance Principle describes adaptive conductance that updates in response to a driving current. Its core equation \(\frac{dG}{dt} = \alpha |I(t)| - \mu G(t)\) models reinforcement and decay rates. Closed‑form solutions and transfer‑function interpretations show that ARP acts as an exponential low‑pass tracker of the absolute current. This repository hosts various Python scripts exploring ARP behaviour, including double‑slit experiments, dynamic resistance simulations and preliminary travelling‑salesperson solvers.</p>
+  <p><a href="index.html">Back to blog index</a></p>
+</body>
+</html>

--- a/site/blog/adaptivecad.html
+++ b/site/blog/adaptivecad.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>AdaptiveCAD</title>
+</head>
+<body>
+  <h1>AdaptiveCAD</h1>
+  <p>AdaptiveCAD is a next‑generation modeling toolkit built on adaptive π geometry. It provides node‑free smooth curves, hyperbolic geometry tools, fast STL repair and smoothing, and 3D‑print export. The toolkit includes a playground application with parametric editors (such as superellipse and πₐ splines) and a live viewport. It also offers libraries of advanced shapes and hyperbolic curves and a repair pipeline for messy meshes. Outputs can be exported as STL/3MF or G‑code, and integrations are available for FreeCAD and Blender.</p>
+  <p><a href="index.html">Back to blog index</a></p>
+</body>
+</html>

--- a/site/blog/arpprimeamp.html
+++ b/site/blog/arpprimeamp.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>ARPPrimeAmp</title>
+</head>
+<body>
+  <h1>ARPPrimeAmp</h1>
+  <p>ARPPrimeAmp is a physics‑inspired composite filter that combines curvature‑adjusted π with an ARP amplifier to score integers. For each candidate divisor a phase defect is computed and exponentiated; the ARP amplifier integrates this resonance score over time to produce a signal \(G_n(t)\). High scores indicate composite numbers, while low scores mark prime candidates. Quickstart scripts demonstrate classifying numbers and include options for GPU/vectorized kernels and hybrid workflows.</p>
+  <p><a href="index.html">Back to blog index</a></p>
+</body>
+</html>

--- a/site/blog/curve-memory.html
+++ b/site/blog/curve-memory.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Curve Memory (CMA)</title>
+</head>
+<body>
+  <h1>Curve Memory (CMA)</h1>
+  <p>Curve Memory encodes curves as memory and memory as curves, sitting at the intersection of adaptive π geometry and the Adaptive Resistance Principle. Updates released in September 2025 integrate adaptive π with dynamic curvature and damping terms, introduce a minimal glyph alphabet parameterized by curvature and torsion and explore wedge‑product compressibility. The repository provides examples and Python implementations for encoding and decoding curve memories and discusses 2D/3D formulations using Frenet–Serret equations and rigid‑motion‑invariant curve descriptors.</p>
+  <p><a href="index.html">Back to blog index</a></p>
+</body>
+</html>

--- a/site/blog/index.html
+++ b/site/blog/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Adaptive Blog</title>
+</head>
+<body>
+  <h1>Adaptive Blog</h1>
+  <ul>
+    <li><a href="adaptivecad.html">AdaptiveCAD</a></li>
+    <li><a href="adaptive-curvature-blockchain.html">Adaptive‑Curvature‑Blockchain (ACB)</a></li>
+    <li><a href="adaptive-physics-engine.html">Adaptive Physics Engine</a></li>
+    <li><a href="adaptive-pi.html">Adaptive π Geometry</a></li>
+    <li><a href="adaptive-platonic-catalogue.html">Adaptive Platonic Catalogue</a></li>
+    <li><a href="adaptive-quantum-coupling.html">Adaptive Quantum Coupling — Bell Chip</a></li>
+    <li><a href="adaptive-resistance-principle.html">Adaptive Resistance Principle (ARP)</a></li>
+    <li><a href="adaptive-compression-suite.html">Adaptive Compression Suite</a></li>
+    <li><a href="adaptive-gravity.html">Adaptive Gravity (Galaxy Rotation Simulation)</a></li>
+    <li><a href="arpprimeamp.html">ARPPrimeAmp</a></li>
+    <li><a href="curve-memory.html">Curve Memory (CMA)</a></li>
+    <li><a href="adaptive-demo-game.html">Adaptive π Demo Game</a></li>
+    <li><a href="adaptive-dynamics-toolkit.html">Adaptive Dynamics Toolkit</a></li>
+    <li><a href="adaptive-golden-field.html">Adaptive Golden Field</a></li>
+  </ul>
+  <p><a href="../index.html">Back to main site</a></p>
+</body>
+</html>

--- a/site/index.html
+++ b/site/index.html
@@ -33,6 +33,7 @@
       <a href="#features" class="hover:text-white">Features</a>
       <a href="#video" class="hover:text-white">Video</a>
       <a href="#faq" class="hover:text-white">FAQ</a>
+      <a href="blog/index.html" class="hover:text-white">Blog</a>
       <a href="https://github.com/RDM3DC/AdaptiveCAD" class="hover:text-white">GitHub</a>
       <a href="https://kickstarter.com/projects/cleandoor/adaptivecad-is-a-next-gen-modeling-toolkit-open-source" class="ml-3 px-4 py-2 rounded-xl bg-teal-400/20 border border-teal-300/50 hover:bg-teal-300/30 text-teal-200">Back on Kickstarter</a>
     </nav>
@@ -104,6 +105,7 @@
     <div class="flex flex-wrap items-center justify-between gap-3">
       <div>© RDM3DC — Adaptive π</div>
       <div class="flex items-center gap-4">
+        <a href="blog/index.html">Blog</a>
         <a href="https://github.com/RDM3DC/AdaptiveCAD">GitHub</a>
         <a href="https://kickstarter.com/projects/cleandoor/adaptivecad-is-a-next-gen-modeling-toolkit-open-source" class="text-teal-300">Kickstarter</a>
       </div>


### PR DESCRIPTION
## Summary
- unpack the provided blog archive into `site/blog` with an index page and individual article stubs
- surface the new blog by linking to it from the main navigation and footer on the landing page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf88b145f8832f97f422eeebb9273a